### PR TITLE
Recreate virtualenv when system Python version changes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,31 @@
     name: "{{ borgmatic_packages }}"
     state: present
 
+- name: Check Python version in existing virtualenv
+  stat:
+    path: "{{ borgmatic_directory }}/bin/python3"
+  register: _borgmatic_venv_python
+
+- name: Get virtualenv Python version
+  command: "{{ borgmatic_directory }}/bin/python3 --version"
+  register: _borgmatic_venv_python_version
+  changed_when: false
+  when: _borgmatic_venv_python.stat.exists
+
+- name: Get system Python version
+  command: "{{ borgmatic_python_command }} --version"
+  register: _borgmatic_system_python_version
+  changed_when: false
+  when: _borgmatic_venv_python.stat.exists
+
+- name: Remove virtualenv if Python version changed
+  file:
+    path: "{{ borgmatic_directory }}"
+    state: absent
+  when:
+    - _borgmatic_venv_python.stat.exists
+    - _borgmatic_venv_python_version.stdout != _borgmatic_system_python_version.stdout
+
 - name: Install setuptools in borgmatic virtual environment
   pip:
     name: setuptools<71


### PR DESCRIPTION
After a distribution upgrade (e.g. Ubuntu 20.04 → 22.04), the Python version changes and the existing virtualenv becomes broken (pip/modules are linked to the old Python).

This adds a check that compares the Python version inside the existing venv with the system Python. If they differ, the venv is removed so subsequent tasks recreate it cleanly.

Tested during a 20.04 → 22.04 upgrade where the borgmatic venv built with Python 3.8 broke after the system moved to Python 3.10.